### PR TITLE
Fixed link to explanatory page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here are some examples that came up during testing:
 ![An estate agent listing with altered text. It says '1 bedroom flat. Shit one bedroom first floor apartment in shit location'](/examples/example3.jpg?raw=true)
 
 ## Visit the website
-I've put together an explanatory page over at <a href="shitemove.angryflatcap.com">shitemove.angryflatcap.com</a>
+I've put together an explanatory page over at <a href="http://shitemove.angryflatcap.com/">shitemove.angryflatcap.com</a>
 
 ## To do
 


### PR DESCRIPTION
Really love the idea for this plugin! Just noticed a broken link to the explanatory page in the README, thought I'd PR to fix it :smile: